### PR TITLE
Clarify that PAT owner needs to have repo access

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ A GitHub action to create a repository dispatch event.
 
 This action creates [`repository_dispatch`](https://developer.github.com/v3/repos/#create-a-repository-dispatch-event) events.
 The default `GITHUB_TOKEN` does not have scopes to do this so a `repo` scoped [PAT](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) is required.
-If you will be dispatching to a public repository then you can use the more limited `public_repo` scope.
+
+If you will be dispatching to a public repository then you can use the more limited `public_repo` scope. Additionally, the user for which the PAT is created needs to have `write` access to the repository.
 
 ## Example
 


### PR DESCRIPTION
Ran into an issue where I was using a user that did not have explicit access to the repo that I was trying to trigger an event for. I'm not sure if the user needs write access to the repo, but it seems logical to me that someone with `read` only access can not trigger GH actions.