### PR TITLE
[docs] make it clear what's required for a same-repo dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,41 @@ A GitHub action to create a repository dispatch event.
 
 ## Usage
 
-Dispatch an event to the current repository.
-```yml
-      - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          event-type: my-event
+### Dispatching an event to the current repository
+
+In the caller workflow file:
+
+```diff
+jobs:
+  your_job_name:
+    runs-on: ubuntu-latest
++    permissions:
++      contents: write
+     steps:
+       …
++       - name: Repository Dispatch
++         uses: peter-evans/repository-dispatch@v3
++         with:
++           event-type: my-event
 ```
 
-Dispatch an event to a remote repository using a `repo` scoped [Personal Access Token (PAT)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token).
+In the callee workflow file:
+
+```diff
+name: YourWorkflow
+
++on:
++  repository_dispatch:
++    types: [my-event]
+
+jobs:
+  …
+```
+
+### Dispatching an event to a remote repository
+
+Use a `repo` scoped [Personal Access Token (PAT)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token).
+
 ```yml
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v3
@@ -28,7 +54,7 @@ Dispatch an event to a remote repository using a `repo` scoped [Personal Access 
 
 | Name | Description | Default |
 | --- | --- | --- |
-| `token` | `GITHUB_TOKEN` (permissions `contents: write`) or a `repo` scoped [Personal Access Token (PAT)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token). See [token](#token) for further details. | `GITHUB_TOKEN` |
+| `token` | `GITHUB_TOKEN` or a `repo` scoped [Personal Access Token (PAT)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token). See [token](#token) for further details. | `GITHUB_TOKEN` |
 | `repository` | The full name of the repository to send the dispatch. | `github.repository` (current repository) |
 | `event-type` | (**required**) A custom webhook event name. | |
 | `client-payload` | JSON payload with extra information about the webhook event that your action or workflow may use. | `{}` |


### PR DESCRIPTION
## Description

A few users are bumping into issues when integrating, including me. I think the docs aren't clear enough - the info is there, somehow, somewhere, but it's not easy to digest. This change makes it more clear what's needed right away.

Resolves #196

## Preview

before|after
--|--
<img width="400" src="https://github.com/user-attachments/assets/85073c84-0318-4420-bd3b-2e3b45b3f5e5">|<img width="400" src="https://github.com/user-attachments/assets/a741c501-2c25-4653-832b-0f5e109cf054"> 

